### PR TITLE
Initial app settings

### DIFF
--- a/.prettierrc
+++ b/.prettierrc
@@ -1,0 +1,5 @@
+{
+  "tabWidth": 2,
+  "semi": true,
+  "singleQuote": false
+}

--- a/.vscode/FunctionComponent.code-snippets
+++ b/.vscode/FunctionComponent.code-snippets
@@ -1,0 +1,33 @@
+{
+  // Place your music_app workspace snippets here. Each snippet is defined under a snippet name and has a scope, prefix, body and
+  // description. Add comma separated ids of the languages where the snippet is applicable in the scope field. If scope
+  // is left empty or omitted, the snippet gets applied to all languages. The prefix is what is
+  // used to trigger the snippet and the body will be expanded and inserted. Possible variables are:
+  // $1, $2 for tab stops, $0 for the final cursor position, and ${1:label}, ${2:another} for placeholders.
+  // Placeholders with the same ids are connected.
+  // Example:
+  // "Print to console": {
+  // 	"scope": "javascript,typescript",
+  // 	"prefix": "log",
+  // 	"body": [
+  // 		"console.log('$1');",
+  // 		"$2"
+  // 	],
+  // 	"description": "Log output to console"
+  // }
+
+  "FunctionComponent": {
+    "prefix": "fnc-cmp",
+    "body": [
+      "interface ${1:$TM_FILENAME_BASE}Props {",
+      "  children?: React.ReactNode;",
+      "};",
+      "",
+      "export const ${1:$TM_FILENAME_BASE} = (props: ${1:$TM_FILENAME_BASE}Props) => {",
+      "  return <div>${2:example}</div>;",
+      "};",
+      ""
+    ],
+    "description": "A code snippet for a functional component. By typing fnc-cmp it will open up your emmet to access this snippet. Clicking enter will create a Functional Component based off the naming convention of the file."
+  }
+}

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,0 +1,4 @@
+{
+  "editor.tabSize": 2,
+  "editor.formatOnSave": true
+}


### PR DESCRIPTION
I've added some initial app settings. I've set formatting on save to true to format the code to our standards whenever the file is saved. Is everyone cool with that?

I've added a code snippet for a functional component that can be accessed by typing `fnc-cmp` which will name the component after your file's naming convention.

I've also added some initial prettier settings for code formatting as well. See this link: https://prettier.io/docs/en/configuration

Any special config anyone can think of to add right now? I'm fond of trailing commas.
 